### PR TITLE
Fix docker-compose and redis container name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - type: bind
         source: ./favicon.png
         target: /usr/local/searxng/searx/static/themes/simple/img/searxng.png
-        type: bind
+      - type: bind
         source: ./base.html
         target: /usr/local/searxng/searx/templates/simple/base.html 
     security_opt:

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -46,4 +46,4 @@ hostname_replace:
    '(www\.)?twitter\.com$': 'tweet.whateveritworks.org'
    'spam\.example\.com': false
 redis:
-  url: redis://redis:6379/0
+  url: redis://searxng-redis:6379/0


### PR DESCRIPTION
Hi,

This fork fix an issue with the bind in the docker compose and in the setting with the redis container name